### PR TITLE
[FeatureMade] FeatureTargetSplit, TrainTestSplit + codes updated

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ export const AppContext = createContext({ dfd, storage });
 
 function App() {
   return (
-    <div className="App h-screen text-base md:text-sm sm:text-xs">
+    <div className="App text-base md:text-sm sm:text-xs">
       <Navbar />
       <DndProvider backend={HTML5Backend}>
         <AppContext.Provider value={{ dfd, storage }}>

--- a/src/MLComponents/Column.jsx
+++ b/src/MLComponents/Column.jsx
@@ -1,8 +1,12 @@
-import React, { useRef } from "react";
+import React, { useRef, createContext } from "react";
 import Row from "MLComponents/Row";
 import { negButtonStyle } from "MLComponents/componentStyle";
 
+export const BlockContext = createContext(); // 해당 블록에 속한 모든 컴포넌트들에 블록 ID를 전달하기 위한 컨텍스트
+
 const Column = ({ data, handleDrop, path, removeBlock }) => {
+  const blockId = data.id; // 블록의 ID
+
   const ref = useRef(null);
 
   const renderRow = (row, currentPath) => {
@@ -24,12 +28,13 @@ const Column = ({ data, handleDrop, path, removeBlock }) => {
           블록 삭제
         </button>
       </div>
+      <BlockContext.Provider value={{ blockId }}>
+        {data.children.map((row, index) => {
+          const currentPath = `${path}-${index}`;
 
-      {data.children.map((row, index) => {
-        const currentPath = `${path}-${index}`;
-
-        return <React.Fragment key={row.id}>{renderRow(row, currentPath)}</React.Fragment>;
-      })}
+          return <React.Fragment key={row.id}>{renderRow(row, currentPath)}</React.Fragment>;
+        })}
+      </BlockContext.Provider>
     </div>
   );
 };

--- a/src/MLComponents/CompoOptions/DataPrep/FeatureTargetSplit.jsx
+++ b/src/MLComponents/CompoOptions/DataPrep/FeatureTargetSplit.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useContext, useRef } from "react";
+import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
+import { AppContext } from "App";
+import { getColumns, saveFeatureTarget, showDataResult } from "MLComponents/CompoOptions/util";
+import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
+
+function FeatureTargetSplit({ formId, resultId }) {
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
+  const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
+
+  const [cols, setCols] = useState([]); // 타겟 컬럼 MultiSelect
+
+  const colsRef = useRef();
+
+  // 컬럼 선택(MultiSelect)
+  const settingCols = (e) => {
+    // console.log(e);
+    setCols([...e.map((col) => col.value)]);
+  };
+
+  // 백앤드로 데이터 전송
+  const handleSubmit = async (event) => {
+    event.preventDefault(); // 실행 버튼 눌러도 페이지 새로고침 안 되도록 하는 것
+
+    // 백앤드 전송을 위한 설정
+    const params = { cols: cols }; // 입력해야 할 파라미터 설정
+    // 입력해야 할 파라미터가 있는지 확인
+    if (cols.length === 0) {
+      // 생성 또는 변경할 컬럼명 입력 여부 확인
+      colsRef.current.focus();
+      return;
+    }
+    // 백앤드 API URL에 파라미터 추가
+    const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.FeatureTargetSplit), params);
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+
+    // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
+    await fetch(targetUrl, httpConfig(JSON.stringify(df)))
+      .then((response) => response.json())
+      .then((data) => {
+        // console.log(data);
+        saveFeatureTarget(blockId, data);
+        showDataResult(dfd, JSON.parse(data).X, resultId);
+      })
+      .catch((error) => console.error(error));
+  };
+
+  return (
+    <form id={formId} onSubmit={handleSubmit}>
+      <div className="flex flex-row items-center">
+        <span className="mr-2">타겟 컬럼 선택</span>
+        <MultiSelect ref={colsRef} options={colObjArray} onChange={settingCols} className="flex-1" isMulti={true} closeMenuOnSelect={false} />
+      </div>
+    </form>
+  );
+}
+
+export default React.memo(FeatureTargetSplit);

--- a/src/MLComponents/CompoOptions/DataPrep/TrainTestSplit.jsx
+++ b/src/MLComponents/CompoOptions/DataPrep/TrainTestSplit.jsx
@@ -1,0 +1,139 @@
+import React, { useState, useContext, useRef } from "react";
+import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
+import { AppContext } from "App";
+import { inputStyle } from "MLComponents/componentStyle";
+import { loadFeatureTarget, saveTrainTest, showDataResult, showShape } from "MLComponents/CompoOptions/util";
+import { Switch } from "MLComponents/CompoOptions/CompoPiece";
+import { BlockContext } from "MLComponents/Column";
+
+function TrainTestSplit({ formId, resultId }) {
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  // const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
+
+  const [testSize, setTestSize] = useState(0.2); // input number 0~1
+  const [trainSize, setTrainSize] = useState(0.8); // input number 0~1
+  const [randomState, setRandomState] = useState(42); // input number int
+  const [shuffle, setShuffle] = useState(false); // Switch
+  const [stratify, setStratify] = useState(false); // Switch
+
+  const testSizeRef = useRef();
+  const trainSizeRef = useRef();
+  const randomStateRef = useRef();
+  const shuffleRef = useRef();
+  const stratifyRef = useRef();
+
+  // 컬럼명 입력 시 변화 감지하여 상태 값 변경
+  const handleChange = (event) => {
+    console.log(event.target.value);
+    switch (event.target) {
+      // 함수 지정 시
+      case testSizeRef.current:
+        setTestSize(event.target.value);
+        break;
+      case trainSizeRef.current:
+        setTrainSize(event.target.value);
+        break;
+      case randomStateRef.current:
+        setRandomState(event.target.value);
+        break;
+      case shuffleRef.current:
+        setShuffle(!shuffle);
+        break;
+      case stratifyRef.current:
+        setStratify(!stratify);
+        break;
+      default:
+        console.log("error");
+        break;
+    }
+  };
+
+  /**
+   *
+   * TODO showDataResult -> shape 출력으로 변경하기
+   */
+  // 백앤드로 데이터 전송
+  const handleSubmit = async (event) => {
+    event.preventDefault(); // 실행 버튼 눌러도 페이지 새로고침 안 되도록 하는 것
+
+    // 백앤드 전송을 위한 설정
+    const params = {
+      test_size: testSize && !trainSize ? testSize : "",
+      train_size: trainSize && !testSize ? trainSize : "",
+      random_state: randomState ? randomState : 42,
+      shuffle: shuffle,
+      stratify: stratify,
+    }; // 입력해야 할 파라미터 설정
+
+    // 입력해야 할 파라미터가 규칙대로 입력되었는지 확인
+    if (testSize && trainSize) {
+      document.getElementById(resultId).innerHTML = "test_size 또는 train_size 둘 중 하나만 입력 가능"; // 올바른 입력이 아니면 에러 메시지 출력
+      return;
+    }
+
+    // 백앤드 API URL에 파라미터 추가
+    const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.TrainTestSplit), params);
+    const df = loadFeatureTarget(blockId);
+
+    // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
+    await fetch(targetUrl, httpConfig(JSON.stringify(df)))
+      .then((response) => response.json())
+      .then((data) => {
+        // console.log(data);
+        saveTrainTest(dfd, blockId, data, resultId);
+        // String(data).startsWith("{") ? showShape(dfd, JSON.parse(data), resultId) : (document.getElementById(resultId).innerHTML = data);
+      })
+      .catch((error) => console.error(error));
+  };
+
+  return (
+    <form id={formId} onSubmit={handleSubmit}>
+      <div className="flex flex-col space-y-2">
+        <div className="grid grid-rows-3 grid-cols-2 space-y-1">
+          <label>테스트셋 비율</label>
+          <input
+            ref={testSizeRef}
+            className={inputStyle}
+            type="number"
+            step="any"
+            min={0}
+            max={1}
+            onChange={handleChange}
+            placeholder="기본값 0.25 / 훈련셋 입력 시 이에 따라 자동 설정"
+            defaultValue={testSize}
+          />
+          <label>훈련셋 비율</label>
+          <input
+            ref={trainSizeRef}
+            className={inputStyle}
+            type="number"
+            step="any"
+            min={0}
+            max={1}
+            onChange={handleChange}
+            placeholder="테스트셋 비율에 따라 자동 설정"
+            defaultValue={trainSize}
+          />
+          <label>시드 값</label>
+          <input
+            ref={randomStateRef}
+            className={inputStyle}
+            type="number"
+            step="any"
+            onChange={handleChange}
+            placeholder="기본값 42"
+            defaultValue={randomState}
+          />
+        </div>
+        <div className="flex flex-row space-x-2">
+          <Switch ref={shuffleRef} text="셔플 여부" onChange={handleChange} checked={shuffle} />
+          <Switch ref={stratifyRef} text="타겟 균등 분포 여부" onChange={handleChange} checked={stratify} />
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export default React.memo(TrainTestSplit);

--- a/src/MLComponents/CompoOptions/DataPrep/index.js
+++ b/src/MLComponents/CompoOptions/DataPrep/index.js
@@ -1,0 +1,4 @@
+import FeatureTargetSplit from "./FeatureTargetSplit";
+import TrainTestSplit from "./TrainTestSplit";
+
+export { FeatureTargetSplit, TrainTestSplit };

--- a/src/MLComponents/CompoOptions/DataUpload.jsx
+++ b/src/MLComponents/CompoOptions/DataUpload.jsx
@@ -2,11 +2,13 @@ import React, { useState, useContext } from "react";
 import { UPLOAD_ACCEPT, MLFUNC_URL, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
 import { funcResultConfig, funcResultLayout } from "MLComponents/CompoOptions/funcResultConfigs";
 import { AppContext } from "App";
+import { BlockContext } from "MLComponents/Column";
 import { saveDf, jsonToFile } from "MLComponents/CompoOptions/util";
 
 function DataUpload({ formId, resultId }) {
   const [file, setFile] = useState();
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
   // 파일 선택 시 선택한 파일 데이터를 file State에 저장
   const handleChange = (event) => {
@@ -32,7 +34,7 @@ function DataUpload({ formId, resultId }) {
           .readJSON(jsonToFile(data))
           .then((df) => {
             df.head().plot(resultId).table({ funcResultConfig, funcResultLayout }); // 결과 영역에 출력
-            saveDf("df", data, true); // 데이터프레임 저장
+            saveDf(blockId, "_df", data, true); // 데이터프레임 저장
           })
           .catch((err) => {
             console.log(err);

--- a/src/MLComponents/CompoOptions/EDA/ColumnList.jsx
+++ b/src/MLComponents/CompoOptions/EDA/ColumnList.jsx
@@ -2,9 +2,11 @@ import React, { useContext } from "react";
 import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
 import { AppContext } from "App";
 import { showDataResult } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function ColumnList({ formId, resultId }) {
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
@@ -13,7 +15,7 @@ function ColumnList({ formId, resultId }) {
     // 백앤드 전송을 위한 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.ColumnList));
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 결과를 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Corr.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Corr.jsx
@@ -3,6 +3,7 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } 
 import { AppContext } from "App";
 import { inputStyle } from "MLComponents/componentStyle";
 import { showDataFrame, getColumns } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function Corr({ formId, resultId }) {
   const [method, setMethod] = useState("pearson"); // 상관 관계 방식
@@ -11,8 +12,9 @@ function Corr({ formId, resultId }) {
   const [colSecond, setColSecond] = useState(""); // 대상 컬럼
 
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   // 상관 관계 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -49,7 +51,7 @@ function Corr({ formId, resultId }) {
     }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Corr), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Describe.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Describe.jsx
@@ -4,16 +4,18 @@ import { AppContext } from "App";
 import { inputStyle } from "MLComponents/componentStyle";
 import { showDataResult } from "MLComponents/CompoOptions/util";
 import Switch from "MLComponents/CompoOptions/CompoPiece/Switch";
+import { BlockContext } from "MLComponents/Column";
 
 function Describe({ formId, resultId }) {
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
   const [percentiles, setPercentiles] = useState(""); // 확인할 퍼센트 수치들
   const [numVisible, setNumVisible] = useState(true); // 수치형 컬럼 표시 여부
   const [objVisible, setObjVisible] = useState(false); // 객체형 컬럼 표시 여부
   const [catVisible, setCatVisible] = useState(false); // 범주형 컬럼 표시 여부
   const [dateVisible, setDateVisible] = useState(false); // 날짜형 컬럼 표시 여부
   const [dateToNum, setDateToNum] = useState(false); // 날짜형 컬럼을 수치형으로 변환할 지 여부
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -59,7 +61,7 @@ function Describe({ formId, resultId }) {
     }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Describe), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Dtype.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Dtype.jsx
@@ -3,9 +3,11 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } 
 import { AppContext } from "App";
 import { funcResultConfig, funcResultLayout } from "MLComponents/CompoOptions/funcResultConfigs";
 import { jsonToFile } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function Dtype({ formId, resultId }) {
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
@@ -14,7 +16,7 @@ function Dtype({ formId, resultId }) {
     // 백앤드 전송을 위한 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Dtype));
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Groupby.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Groupby.jsx
@@ -4,9 +4,13 @@ import { AppContext } from "App";
 import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import { Select, Switch } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 function Groupby({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colFromArray = [...columns];
   const colToArray = [...columns];
   colFromArray.unshift("처음");
@@ -33,8 +37,6 @@ function Groupby({ formId, resultId }) {
   const groupKeysRef = useRef();
   const observedRef = useRef();
   const dropnaRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingBy = (e) => {
@@ -90,7 +92,7 @@ function Groupby({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Groupby), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Head.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Head.jsx
@@ -3,10 +3,13 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } 
 import { AppContext } from "App";
 import { inputStyle } from "MLComponents/componentStyle";
 import { showDataResult } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function Head({ formId, resultId }) {
-  const [lineNum, setLineNum] = useState();
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const [lineNum, setLineNum] = useState();
 
   // 숫자 입력 시 변화 감지하여 상태 값 변경
   const handleChange = (event) => {
@@ -21,7 +24,7 @@ function Head({ formId, resultId }) {
     const params = { line: lineNum }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Head), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/IsNa.jsx
+++ b/src/MLComponents/CompoOptions/EDA/IsNa.jsx
@@ -4,10 +4,13 @@ import { AppContext } from "App";
 import { inputStyle } from "MLComponents/componentStyle";
 import { funcResultConfig, funcResultLayout } from "MLComponents/CompoOptions/funcResultConfigs";
 import { jsonToFile } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function IsNa({ formId, resultId }) {
-  const [isSum, setIsSum] = useState();
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const [isSum, setIsSum] = useState();
 
   // 결측치 개수 합계 표시 여부 상태 값 저장
   const handleChange = (event) => {
@@ -23,7 +26,7 @@ function IsNa({ formId, resultId }) {
     const params = { sum: isSum }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.IsNa), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Shape.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Shape.jsx
@@ -1,9 +1,11 @@
 import React, { useContext } from "react";
 import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
 import { AppContext } from "App";
+import { BlockContext } from "MLComponents/Column";
 
 function Shape({ formId, resultId }) {
   const { storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
@@ -12,7 +14,7 @@ function Shape({ formId, resultId }) {
     // 백앤드 전송을 위한 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Shape));
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Tail.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Tail.jsx
@@ -4,10 +4,13 @@ import { AppContext } from "App";
 import { inputStyle } from "MLComponents/componentStyle";
 import { funcResultConfig, funcResultLayout } from "MLComponents/CompoOptions/funcResultConfigs";
 import { jsonToFile } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function Tail({ formId, resultId }) {
-  const [lineNum, setLineNum] = useState();
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const [lineNum, setLineNum] = useState();
 
   // 숫자 입력 시 변화 감지하여 상태 값 변경
   const handleChange = (event) => {
@@ -22,7 +25,7 @@ function Tail({ formId, resultId }) {
     const params = { line: lineNum }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Tail), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/EDA/Unique.jsx
+++ b/src/MLComponents/CompoOptions/EDA/Unique.jsx
@@ -3,12 +3,15 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } 
 import { AppContext } from "App";
 import { getColumns, showDataResult } from "MLComponents/CompoOptions/util";
 import Select from "MLComponents/CompoOptions/CompoPiece/Select";
+import { BlockContext } from "MLComponents/Column";
 
 function Unique({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const [column, setColumn] = useState(columns[0]);
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼명 입력 시 변화 감지하여 상태 값 변경
   const handleChange = (event) => {
@@ -24,7 +27,7 @@ function Unique({ formId, resultId }) {
     const params = { col: column }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Unique), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/ColConditionDf.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/ColConditionDf.jsx
@@ -5,9 +5,13 @@ import { inputStyle } from "MLComponents/componentStyle";
 import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import classNames from "classnames";
 import Select from "MLComponents/CompoOptions/CompoPiece/Select";
+import { BlockContext } from "MLComponents/Column";
 
 function ColConditionDf({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const [col, setCol] = useState(columns[0]); // 조건의 기준이 될 컬럼
   const [cond1, setCond1] = useState("eq"); // 조건 1 "eq", "gr", "gr_eq", "le", "le_eq"
@@ -17,8 +21,6 @@ function ColConditionDf({ formId, resultId }) {
   const [cond2Temp, setCond2Temp] = useState(""); // 조건 2 임시 저장
   const [value2Temp, setValue2Temp] = useState(""); // 조건 2 값 임시 저장
   const [cond2Visible, setCond2Visible] = useState(false); // 조건 2 표시 여부(조건 1이 "eq"가 아니면 표시)
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -73,7 +75,7 @@ function ColConditionDf({ formId, resultId }) {
     }; // 입력해야 할 파라미터 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.ColConditionDf), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/Drop.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/Drop.jsx
@@ -1,14 +1,18 @@
-import React, { useState, useContext, useRef, useEffect } from "react";
+import React, { useState, useContext, useRef } from "react";
 import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
 import { AppContext } from "App";
-import { saveDf, showDataResult, getColumns, saveColumnList } from "MLComponents/CompoOptions/util";
+import { saveDf, showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import { inputStyle } from "MLComponents/componentStyle";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
 import classNames from "classnames";
+import { BlockContext } from "MLComponents/Column";
 
 function Drop({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
 
   const [labelsCol, setLabelsCol] = useState([]); // MultiSelect
@@ -23,8 +27,6 @@ function Drop({ formId, resultId }) {
   const labelsIndexRef = useRef();
   const axisRef = useRef();
   const errorsRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingLabelsCol = (e) => {
@@ -80,13 +82,13 @@ function Drop({ formId, resultId }) {
     }
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Drop), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))
       .then((response) => response.json())
       .then((data) => {
-        saveDf("df", data, true); // 데이터프레임 저장
+        saveDf(blockId, "_df", data, true); // 데이터프레임 저장
         showDataResult(dfd, data, resultId);
 
         // 컬럼 삭제한 경우 새로운 컬럼 목록 가져와서 입력 목록에 넣기

--- a/src/MLComponents/CompoOptions/Preprocess/DropNa.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/DropNa.jsx
@@ -6,9 +6,13 @@ import { inputStyle } from "MLComponents/componentStyle";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
 import classNames from "classnames";
+import { BlockContext } from "MLComponents/Column";
 
 function DropNa({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
 
   const [axis, setAxis] = useState(0); // Select 축 선택(0: 행, 1: 열)
@@ -21,8 +25,6 @@ function DropNa({ formId, resultId }) {
   const howRef = useRef();
   const threshRef = useRef();
   const subsetRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingSubset = (e) => {
@@ -61,14 +63,14 @@ function DropNa({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.DropNa), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))
       .then((response) => response.json())
       .then((data) => {
         // console.log(data);
-        saveDf("df", data, true); // 데이터프레임 저장
+        saveDf(blockId, "_df", data, true); // 데이터프레임 저장
         showDataResult(dfd, data, resultId);
 
         // 컬럼 삭제된 경우 새로운 컬럼 목록 가져와서 입력 목록에 넣기

--- a/src/MLComponents/CompoOptions/Preprocess/ILocDf.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/ILocDf.jsx
@@ -6,9 +6,13 @@ import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import classNames from "classnames";
 import { Select, Switch } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 function ILocDf({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const columnIdxs = columns.map((_, idx) => String(idx)); // 컬럼 인덱스 목록
   const colFromArray = [...columnIdxs];
   const colToArray = [...columnIdxs];
@@ -44,8 +48,6 @@ function ILocDf({ formId, resultId }) {
   const isColRangeRef = useRef();
   const colDiscreteRef = useRef();
   const colRangeRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingCols = (e) => {
@@ -102,7 +104,7 @@ function ILocDf({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.ILocDf), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/LocDf.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/LocDf.jsx
@@ -5,11 +5,14 @@ import { inputStyle } from "MLComponents/componentStyle";
 import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import classNames from "classnames";
 import { Select, Switch } from "MLComponents/CompoOptions/CompoPiece";
-// import { MultiSelect } from "react-multi-select-component";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 function LocDf({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colFromArray = [...columns];
   const colToArray = [...columns];
   colFromArray.unshift("처음");
@@ -47,8 +50,6 @@ function LocDf({ formId, resultId }) {
   const isColRangeRef = useRef();
   const colDiscreteRef = useRef();
   const colRangeRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingCols = (e) => {
@@ -135,7 +136,7 @@ function LocDf({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.LocDf), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/RenameCol.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/RenameCol.jsx
@@ -5,9 +5,13 @@ import { saveDf, showDataResult, getColumns } from "MLComponents/CompoOptions/ut
 import { inputStyle } from "MLComponents/componentStyle";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 function RenameCol({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
 
   const [keys, setKeys] = useState([]); // input text 변경될 컬럼명
@@ -20,8 +24,6 @@ function RenameCol({ formId, resultId }) {
   const valuesRef = useRef();
   // const copyRef = useRef();
   const errorsRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   const settingKeys = (e) => {
     // console.log(e);
@@ -63,13 +65,13 @@ function RenameCol({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.RenameCol), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))
       .then((response) => response.json())
       .then((data) => {
-        saveDf("df", data, true); // 데이터프레임 저장
+        saveDf(blockId, "_df", data, true); // 데이터프레임 저장
         showDataResult(dfd, data, resultId);
       })
       .catch((error) => console.error(error));

--- a/src/MLComponents/CompoOptions/Preprocess/SetColumn.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/SetColumn.jsx
@@ -5,8 +5,8 @@ import { inputStyle } from "MLComponents/componentStyle";
 import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import classNames from "classnames";
 import { Select, Switch } from "MLComponents/CompoOptions/CompoPiece";
-// import { MultiSelect } from "react-multi-select-component";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 /**
  * 새로운 컬럼을 생성하거나 기존의 컬럼을 변경하기 위한 컴포넌트.
@@ -15,7 +15,10 @@ import MultiSelect from "react-select";
  * 2. cols_ops
  */
 function SetColumn({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const colFromArray = [...columns];
   const colToArray = [...columns];
@@ -39,7 +42,7 @@ function SetColumn({ formId, resultId }) {
 
   // 방법 2 관련 상태 값
   const [colsOps, setColsOps] = useState([]); // 사칙연산에 필요한 컬럼과 연산자들 input text readonly
-  console.log(colsOps);
+  // console.log(colsOps);
   const [colsOpsCol, setColsOpsCol] = useState(columns[0]); // 사칙연산에 필요한 컬럼 선택 Select
   const [colsOpsVal, setColsOpsVal] = useState(0); // 사칙연산에 필요한 컬럼 선택 Select
   const [colsOpsOp, setColsOpsOp] = useState(colOps[0]); // 사칙연산에 필요한 연산자 선택 Select
@@ -71,8 +74,6 @@ function SetColumn({ formId, resultId }) {
 
   const isColsOpsRef = useRef();
   const isColRangeRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingCols = (e) => {
@@ -156,7 +157,7 @@ function SetColumn({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.SetColumn), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/SortValue.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/SortValue.jsx
@@ -4,9 +4,13 @@ import { AppContext } from "App";
 import { showDataResult, getColumns } from "MLComponents/CompoOptions/util";
 import { Select, Switch } from "MLComponents/CompoOptions/CompoPiece";
 import MultiSelect from "react-select";
+import { BlockContext } from "MLComponents/Column";
 
 function SortValue({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
 
   const [by, setBy] = useState(columns[0]); // MultiSelect
@@ -25,8 +29,6 @@ function SortValue({ formId, resultId }) {
   const kindRef = useRef();
   const NaPosRef = useRef();
   const IgIdxRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingBy = (e) => {
@@ -83,7 +85,7 @@ function SortValue({ formId, resultId }) {
     }
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.SortValue), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Preprocess/Transpose.jsx
+++ b/src/MLComponents/CompoOptions/Preprocess/Transpose.jsx
@@ -2,9 +2,11 @@ import React, { useContext } from "react";
 import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } from "MLComponents/CompoOptions/networkConfigs";
 import { AppContext } from "App";
 import { saveDf, showDataResult } from "MLComponents/CompoOptions/util";
+import { BlockContext } from "MLComponents/Column";
 
 function Transpose({ formId, resultId }) {
   const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
@@ -13,13 +15,13 @@ function Transpose({ formId, resultId }) {
     // 백앤드 전송을 위한 설정
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.Transpose));
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))
       .then((response) => response.json())
       .then((data) => {
-        saveDf("df", data, true); // 데이터프레임 저장
+        saveDf(blockId, "_df", data, true); // 데이터프레임 저장
         showDataResult(dfd, data, resultId); // JSON 데이터프레임 문자열을 담은 파일을 읽어서 데이터프레임으로 만든 후 보여주기
         // saveDf("df", data); // 데이터프레임 저장
       })

--- a/src/MLComponents/CompoOptions/Visualization/BoxPlot.jsx
+++ b/src/MLComponents/CompoOptions/Visualization/BoxPlot.jsx
@@ -4,9 +4,13 @@ import { AppContext } from "App";
 import { showPlot, getColumns } from "MLComponents/CompoOptions/util";
 import MultiSelect from "react-select";
 import { ColorPicker } from "MLComponents/CompoOptions/CompoPiece";
+import { BlockContext } from "MLComponents/Column";
 
 function BoxPlot({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
   const colObjArray = [...columns.map((column) => ({ label: column, value: column }))]; // MultiSelect에서 사용하는 객체 목록
 
   const [cols, setCols] = useState(columns[0]); // MultiSelect
@@ -17,8 +21,6 @@ function BoxPlot({ formId, resultId }) {
 
   // DOM 접근 위한 Ref
   const colsRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 컬럼 선택(MultiSelect)
   const settingCols = (e) => {
@@ -40,7 +42,7 @@ function BoxPlot({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS.BoxPlot), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Visualization/CountPlot.jsx
+++ b/src/MLComponents/CompoOptions/Visualization/CountPlot.jsx
@@ -4,9 +4,13 @@ import { AppContext } from "App";
 import { showPlot, getColumns } from "MLComponents/CompoOptions/util";
 import { inputStyle } from "MLComponents/componentStyle";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
+import { BlockContext } from "MLComponents/Column";
 
 function CountPlot({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const [col, setCol] = useState(columns[0]); // Select
   const [title, setTitle] = useState(""); // input text
@@ -18,8 +22,6 @@ function CountPlot({ formId, resultId }) {
   const titleRef = useRef();
   const heightRef = useRef();
   const widthRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -57,7 +59,7 @@ function CountPlot({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS.CountPlot), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Visualization/HistPlot.jsx
+++ b/src/MLComponents/CompoOptions/Visualization/HistPlot.jsx
@@ -3,16 +3,18 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS, httpConfig 
 import { AppContext } from "App";
 import { showPlot, getColumns } from "MLComponents/CompoOptions/util";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
+import { BlockContext } from "MLComponents/Column";
 
 function HistPlot({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const [col, setCol] = useState(columns[0]); // Select
 
   // DOM 접근 위한 Ref
   const colRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -38,7 +40,7 @@ function HistPlot({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS.HistPlot), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/Visualization/ScatterPlot.jsx
+++ b/src/MLComponents/CompoOptions/Visualization/ScatterPlot.jsx
@@ -3,9 +3,13 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS, httpConfig 
 import { AppContext } from "App";
 import { showPlot, getColumns } from "MLComponents/CompoOptions/util";
 import { Select } from "MLComponents/CompoOptions/CompoPiece";
+import { BlockContext } from "MLComponents/Column";
 
 function ScatterPlot({ formId, resultId }) {
-  const columns = getColumns(); // 데이터프레임 컬럼 목록 가져오기
+  const { dfd, storage } = useContext(AppContext);
+  const { blockId } = useContext(BlockContext);
+
+  const columns = getColumns(blockId); // 데이터프레임 컬럼 목록 가져오기
 
   const [xCol, setXCol] = useState(columns[0]); // Select
   const [yCol, setYCol] = useState(columns[0]); // Select
@@ -13,8 +17,6 @@ function ScatterPlot({ formId, resultId }) {
   // DOM 접근 위한 Ref
   const xColRef = useRef();
   const yColRef = useRef();
-
-  const { dfd, storage } = useContext(AppContext);
 
   // 옵션 상태 값 저장
   const handleChange = (event) => {
@@ -44,7 +46,7 @@ function ScatterPlot({ formId, resultId }) {
     console.log(params);
     // 백앤드 API URL에 파라미터 추가
     const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_PLOT, URLS_PREPROCESS.ScatterPlot), params);
-    const df = storage.getItem("df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
+    const df = storage.getItem(blockId + "_df"); // 기존에 스토리지에 저장되어 있던 데이터프레임(JSON) 가져오기
 
     // 데이터 전송 후 받아온 데이터프레임을 사용자에게 보여주기 위한 코드
     await fetch(targetUrl, httpConfig(JSON.stringify(df)))

--- a/src/MLComponents/CompoOptions/index.js
+++ b/src/MLComponents/CompoOptions/index.js
@@ -2,6 +2,7 @@ import DataUpload from "./DataUpload";
 import { ColumnList, Corr, Describe, Dtype, Groupby, Head, IsNa, Shape, Tail, Unique } from "./EDA";
 import { ColConditionDf, Drop, DropNa, ILocDf, LocDf, RenameCol, SortValue, SetColumn, Transpose } from "./Preprocess";
 import { BoxPlot, HistPlot, CountPlot, ScatterPlot } from "./Visualization";
+import { FeatureTargetSplit, TrainTestSplit } from "./DataPrep";
 
 export {
   DataUpload,
@@ -28,4 +29,6 @@ export {
   HistPlot,
   CountPlot,
   ScatterPlot,
+  FeatureTargetSplit,
+  TrainTestSplit,
 };

--- a/src/MLComponents/CompoOptions/networkConfigs.js
+++ b/src/MLComponents/CompoOptions/networkConfigs.js
@@ -39,6 +39,10 @@ export const URLS_PREPROCESS = {
   HistPlot: "histplot",
   CountPlot: "countplot",
   ScatterPlot: "scatterplot",
+
+  // 데이터셋 분할
+  FeatureTargetSplit: "feature_target_split",
+  TrainTestSplit: "train_test_split",
 };
 
 // fetch API로 HTTP 통신하기 위한 설정

--- a/src/MLComponents/CompoOptions/util.js
+++ b/src/MLComponents/CompoOptions/util.js
@@ -2,14 +2,67 @@ import { targetURL, MLFUNC_URL, MLFUNC_SUFFIX_DF, URLS_PREPROCESS, httpConfig } 
 import { funcResultConfig, funcResultLayout } from "MLComponents/CompoOptions/funcResultConfigs";
 
 // 백앤드로 보내 가공 처리한 데이터프레임을 웹 스토리지에 저장
-export const saveDf = (name, df, saveColumns = false) => {
-  console.log("saveDf");
+export const saveDf = (blockId, name, df, saveColumns = false) => {
+  console.log("saveDf name : " + blockId + name);
   if (String(df).startsWith("{") || String(df).startsWith("{", 1)) {
     if (saveColumns) {
-      saveColumnList(df); // 컬럼 리스트 저장
+      saveColumnList(blockId, df); // 컬럼 리스트 저장
     }
-    window.sessionStorage.setItem(name, df); // 웹 스토리지에 데이터프레임(JSON) 저장
+    window.sessionStorage.setItem(blockId + name, df); // 웹 스토리지에 데이터프레임(JSON) 저장
   }
+};
+
+// 데이터셋의 특성 / 타겟 분리하여 각각 웹 스토리지에 저장
+export const saveFeatureTarget = (blockId, data) => {
+  if (String(data).startsWith("{") || String(data).startsWith("{", 1)) {
+    console.log(JSON.parse(data).X);
+    console.log(JSON.parse(data).y);
+    window.sessionStorage.setItem(blockId + "_X", JSON.parse(data).X); // 웹 스토리지에 특성 데이터프레임(JSON) 저장
+    window.sessionStorage.setItem(blockId + "_y", JSON.parse(data).y); // 웹 스토리지에 타겟 데이터프레임(JSON) 저장
+  }
+};
+
+// 데이터셋의 특성 / 타겟 불러오기
+export const loadFeatureTarget = (blockId) => {
+  const dfX = window.sessionStorage.getItem(blockId + "_X"); // 웹 스토리지에 특성 데이터프레임(JSON) 저장
+  const dfy = window.sessionStorage.getItem(blockId + "_y"); // 웹 스토리지에 타겟 데이터프레임(JSON) 저장
+  return { X: dfX, y: dfy };
+};
+
+export const saveTrainTest = (dfd, blockId, data, resultId, val = false) => {
+  if (String(data).startsWith("{") || String(data).startsWith("{", 1)) {
+    // console.log(JSON.parse(data).X_train);
+    // console.log(JSON.parse(data).X_test);
+    // console.log(JSON.parse(data).y_train);
+    // console.log(JSON.parse(data).y_test);
+    window.sessionStorage.setItem(blockId + "_XTrain", JSON.parse(data).X_train); // 웹 스토리지에 특성 훈련 데이터프레임(JSON) 저장
+    window.sessionStorage.setItem(blockId + "_XTest", JSON.parse(data).X_test); // 웹 스토리지에 특성 테스트 데이터프레임(JSON) 저장
+    window.sessionStorage.setItem(blockId + "_yTrain", JSON.parse(data).y_train); // 웹 스토리지에 타겟 훈련 데이터프레임(JSON) 저장
+    window.sessionStorage.setItem(blockId + "_yTest", JSON.parse(data).y_test); // 웹 스토리지에 타겟 테스트 데이터프레임(JSON) 저장
+    if (val) {
+      window.sessionStorage.setItem(blockId + "_XTest", JSON.parse(data).X_val); // 웹 스토리지에 특성 검증 데이터프레임(JSON) 저장
+      window.sessionStorage.setItem(blockId + "_yTest", JSON.parse(data).y_val); // 웹 스토리지에 타겟 검증 데이터프레임(JSON) 저장
+    }
+    // dfd.readJSON(jsonToFile(JSON.parse(data).X_train)).then((df) => {
+    //   document.getElementById(resultId).innerHTML = "<p>Train Set Shape : " + df.shape + "</p>";
+    // });
+    // dfd.readJSON(jsonToFile(JSON.parse(data).X_test)).then((df) => {
+    //   document.getElementById(resultId).append("Test Set Shape : " + df.shape);
+    // });
+    showShape(dfd, JSON.parse(data), resultId);
+  } else {
+    document.getElementById(resultId).innerHTML = data; // 올바른 입력이 아니면 에러 메시지 출력
+  }
+};
+
+// train_test_split 수행 후 shape 보여주기 위한 함수
+export const showShape = (dfd, data, resultId) => {
+  dfd.readJSON(jsonToFile(data.X_train)).then((df) => {
+    document.getElementById(resultId).innerHTML = "<p>Train Set Shape : " + df.shape + "</p>";
+  });
+  dfd.readJSON(jsonToFile(data.X_test)).then((df) => {
+    document.getElementById(resultId).append("Test Set Shape : " + df.shape);
+  });
 };
 
 // 백앤드에서 받은 JSON 데이터프레임 문자열을 임시 파일로 만드는 함수
@@ -51,22 +104,22 @@ export const showDataResult = (dfd, data, resultId) => {
 };
 
 // 세션 스토리지에 데이터프레임의 컬럼 목록 저장하는 함수
-export const saveColumnList = async (df) => {
+export const saveColumnList = async (blockId, df) => {
   const targetUrl = targetURL(MLFUNC_URL.concat(MLFUNC_SUFFIX_DF, URLS_PREPROCESS.ColumnList));
 
   await fetch(targetUrl, httpConfig(JSON.stringify(df)))
     .then((response) => response.json())
     .then((data) => {
       console.log("saveColumnList");
-      window.sessionStorage.setItem("columns", data);
+      window.sessionStorage.setItem(blockId + "_columns", data);
     })
     .catch((error) => console.error(error));
 };
 
-export const getColumns = () => {
-  if (window.sessionStorage.getItem("columns") !== null) {
+export const getColumns = (blockId) => {
+  if (window.sessionStorage.getItem(blockId + "_columns") !== null) {
     return window.sessionStorage
-      .getItem("columns")
+      .getItem(blockId + "_columns")
       .replace(/['\[\]]/g, "")
       .split(",")
       .map((element) => {

--- a/src/MLComponents/Component.jsx
+++ b/src/MLComponents/Component.jsx
@@ -64,6 +64,8 @@ const Component = ({ data, compoType, path }) => {
     "HistPlot",
     "CountPlot",
     "ScatterPlot",
+    "FeatureTargetSplit",
+    "TrainTestSplit",
   ];
   let Options = AllCompo[data.func];
   if (!OptionList.includes(data.func)) {

--- a/src/MLComponents/constants.js
+++ b/src/MLComponents/constants.js
@@ -43,6 +43,10 @@ export const FUNCS_CODE = {
   CountPlot: "CountPlot",
   ScatterPlot: "ScatterPlot",
 
+  // 데이터셋 분할
+  FeatureTargetSplit: "FeatureTargetSplit",
+  TrainTestSplit: "TrainTestSplit",
+
   //temporary
   Fit: "Fit",
   Tuning: "Tuning",
@@ -244,6 +248,20 @@ export const ITEMS_PREPROCESS = [
     func: FUNCS_CODE.ScatterPlot,
     title: "ScatterPlot",
     content: "ScatterPlot Function",
+  },
+  {
+    id: FUNCS_CODE.FeatureTargetSplit,
+    type: SIDEBAR_ITEM + PREPROCESS,
+    func: FUNCS_CODE.FeatureTargetSplit,
+    title: "Feature/Target Split",
+    content: "Feature/Target Split Function",
+  },
+  {
+    id: FUNCS_CODE.TrainTestSplit,
+    type: SIDEBAR_ITEM + PREPROCESS,
+    func: FUNCS_CODE.TrainTestSplit,
+    title: "Train Test Split",
+    content: "Train Test Split Function",
   },
 ];
 

--- a/src/MLComponents/initial-data-test.js
+++ b/src/MLComponents/initial-data-test.js
@@ -19,7 +19,7 @@ const initialData = {
             {
               id: shortid.generate(),
               type: PREPROCESS,
-              func: FUNCS_CODE.SetColumn,
+              func: FUNCS_CODE.TrainTestSplit,
             },
           ],
         },


### PR DESCRIPTION
### 작성자
안경호

### 1. 기능 설명
- FeatureTargetSplit
전체 데이터셋을 백앤드로 보내 특성/타겟으로 나눠진 것을 각각 웹 스토리지에 저장

- TrainTestSplit
특성/타겟 데이터셋을 백앤드로 보내 훈련/테스트셋으로 나눠진 것을 각각 웹 스토리지에 저장

### 2. 인풋(매개변수) & 아웃풋(return 값) (optional)
- FeatureTargetSplit
인풋 : JSON으로 변환된 데이터프레임 전체  
아웃풋 : 특성/타겟으로 나눠진 JSON 데이터프레임&시리즈

- TrainTestSplit
인풋 : 특성/타겟으로 나눠진 JSON 데이터프레임/시리즈  
아웃풋 : 훈련/테스트셋으로 나눠진 JSON 데이터프레임&시리즈