### PR TITLE
JWT setting added

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,19 @@ function App() {
   const [userNickname, setUserNickname] = React.useState(localStorage.getItem("AIPLAY_USER_NICKNAME"));
   const [isSignInOpenFromHome, setIsSignInOpenFromHome] = React.useState(false);
 
+  const refreshTokenInterval = React.useRef(null);
+
   return (
-    <AppContext.Provider value={{ userIdx, setUserIdx, userNickname, setUserNickname, isSignInOpenFromHome, setIsSignInOpenFromHome }}>
+    <AppContext.Provider
+      value={{
+        userIdx,
+        setUserIdx,
+        userNickname,
+        setUserNickname,
+        isSignInOpenFromHome,
+        setIsSignInOpenFromHome,
+        refreshTokenInterval,
+      }}>
       <Routes>
         <Route path="/mlml" element={<MLML />} />
         <Route element={<ServiceIntro />}>

--- a/src/MLML/Chatting/Chat.jsx
+++ b/src/MLML/Chatting/Chat.jsx
@@ -10,7 +10,6 @@ function Chat({ props, handleImgError }) {
   const { userIdx, userNickname } = useContext(AppContext);
 
   const [msgs, setMsgs] = useState([]);
-  console.log(msgs);
 
   const chatBodyRef = useRef(null);
 

--- a/src/MLML/MLComponents/CompoOptions/DataPrep/FeatureTargetSplit.jsx
+++ b/src/MLML/MLComponents/CompoOptions/DataPrep/FeatureTargetSplit.jsx
@@ -5,7 +5,7 @@ import { getColumns, saveFeatureTarget, showDataResult } from "MLML/MLComponents
 import MultiSelect from "react-select";
 import { BlockContext } from "MLML/MLComponents/Column";
 
-function FeatureTargetSplit({ formId, resultId, param, setParam }) {
+function FeatureTargetSplit({ formId, resultId, param, setParam, isLoading, setIsLoading, render }) {
   const { dfd, storage } = useContext(MLMLContext);
   const { blockId } = useContext(BlockContext);
 
@@ -24,6 +24,7 @@ function FeatureTargetSplit({ formId, resultId, param, setParam }) {
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
+    setIsLoading(true); // 로딩 시작
     event.preventDefault(); // 실행 버튼 눌러도 페이지 새로고침 안 되도록 하는 것
 
     // 입력해야 할 파라미터가 있는지 확인
@@ -47,6 +48,7 @@ function FeatureTargetSplit({ formId, resultId, param, setParam }) {
         showDataResult(dfd, JSON.parse(data).X, resultId);
       })
       .catch((error) => console.error(error));
+    setIsLoading(false); // 로딩 종료
   };
 
   return (

--- a/src/MLML/MLComponents/CompoOptions/DataPrep/TrainTestSplit.jsx
+++ b/src/MLML/MLComponents/CompoOptions/DataPrep/TrainTestSplit.jsx
@@ -7,7 +7,7 @@ import { loadFeatureTarget, saveTrainTest, showShape } from "MLML/MLComponents/C
 import { Switch } from "MLML/MLComponents/CompoOptions/CompoPiece";
 import { BlockContext } from "MLML/MLComponents/Column";
 
-function TrainTestSplit({ formId, resultId, param, setParam }) {
+function TrainTestSplit({ formId, resultId, param, setParam, isLoading, setIsLoading, render }) {
   const { dfd } = useContext(MLMLContext);
   const { blockId } = useContext(BlockContext);
 
@@ -29,6 +29,7 @@ function TrainTestSplit({ formId, resultId, param, setParam }) {
 
   // 백앤드로 데이터 전송
   const handleSubmit = async (event) => {
+    setIsLoading(true); // 로딩 시작
     event.preventDefault(); // 실행 버튼 눌러도 페이지 새로고침 안 되도록 하는 것
 
     // 백앤드 API URL에 파라미터 추가
@@ -43,6 +44,7 @@ function TrainTestSplit({ formId, resultId, param, setParam }) {
         showShape(dfd, JSON.parse(data), resultId, param.valid);
       })
       .catch((error) => console.error(error));
+    setIsLoading(false); // 로딩 종료
   };
 
   return (

--- a/src/MLML/MLComponents/CompoOptions/networkConfigs.js
+++ b/src/MLML/MLComponents/CompoOptions/networkConfigs.js
@@ -91,6 +91,8 @@ export const URLS_USER_AUTH = {
   pw_change: "pw_change",
   profile_pic_change: "profile_pic_change",
   inactive: "inactive",
+  refresh_jwt: "refresh_jwt",
+  remove_jwt: "remove_jwt",
 };
 
 export const URLS_DL_API = {

--- a/src/MLML/Navbar/Navbar.jsx
+++ b/src/MLML/Navbar/Navbar.jsx
@@ -1,5 +1,6 @@
 import logoNav from "assets/logo_nav.png";
 import React, { useState, useContext, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { AppContext } from "App";
 import { Disclosure } from "@headlessui/react";
 import { Link } from "react-router-dom";
@@ -12,13 +13,15 @@ import SignIn from "ServiceIntro/UserAuthFuncs/SignIn";
 import FindPw from "ServiceIntro/UserAuthFuncs/FindPw";
 import UserProfile from "ServiceIntro/UserAuthFuncs/UserProfile";
 import errorPic from "assets/error_pic.png";
-
+import { removeToken } from "utils/auth";
 function Navbar({ props, isMLML }) {
-  const { userIdx, isSignInOpenFromHome } = useContext(AppContext);
+  const navigate = useNavigate();
+
+  const { userIdx, setUserIdx, setUserNickname, isSignInOpenFromHome, refreshTokenInterval } = useContext(AppContext);
 
   const [profilePic, setProfilePic] = useState(localStorage.getItem("AIPLAY_USER_PIC"));
 
-  const [loggedIn, setLoggedIn] = useState(userIdx);
+  const [loggedIn, setLoggedIn] = useState(userIdx ? true : false);
 
   const [isServiceUsageOpen, setIsServiceUsageOpen] = useState(false);
   const [isSignInOpen, setIsSignInOpen] = useState(false);
@@ -48,6 +51,14 @@ function Navbar({ props, isMLML }) {
     localStorage.removeItem("aiplay_proj_idx");
     sessionStorage.clear();
     setLoggedIn(false);
+    setUserIdx(null);
+    setUserNickname(null);
+    setProfilePic(null);
+
+    // 1시간마다 갱신하던 토큰을 제거
+    clearInterval(refreshTokenInterval.current);
+    removeToken();
+    navigate("/");
   };
 
   const handleImgError = useCallback((e) => {

--- a/src/ServiceIntro/UserAuthFuncs/ProfilePic.jsx
+++ b/src/ServiceIntro/UserAuthFuncs/ProfilePic.jsx
@@ -15,7 +15,7 @@ function ProfilePic({ profilePic, setProfilePic }) {
     console.log("image upload");
     const formData = new FormData();
     formData.append("profile_pic", e.target.files[0]);
-    formData.append("user_idx", userIdx);
+    formData.append("idx", userIdx);
 
     const config = {
       method: "POST",

--- a/src/ServiceIntro/UserAuthFuncs/SignIn.jsx
+++ b/src/ServiceIntro/UserAuthFuncs/SignIn.jsx
@@ -6,9 +6,10 @@ import { HiX } from "react-icons/hi";
 import { AiFillEye, AiFillEyeInvisible } from "react-icons/ai";
 import { inputStyle } from "MLML/MLComponents/componentStyle";
 import { targetURL, httpConfig, USER_AUTH_URL, URLS_USER_AUTH } from "MLML/MLComponents/CompoOptions/networkConfigs";
+import { refreshToken } from "utils/auth";
 
 function SignIn({ isOpen, openerStates, setProfilePic }) {
-  const { setUserIdx, setIsSignInOpenFromHome } = useContext(AppContext);
+  const { setUserIdx, setUserNickname, setIsSignInOpenFromHome, refreshTokenInterval } = useContext(AppContext);
 
   const setIsOpen = openerStates.setIsSignInOpen;
   const setIsSignUpOpen = openerStates.setIsSignUpOpen;
@@ -39,7 +40,6 @@ function SignIn({ isOpen, openerStates, setProfilePic }) {
   }, [isOpen]);
 
   const handleChange = _.debounce((event) => {
-    console.log(event.target);
     const { name, value } = event.target;
     setInput({
       ...input,
@@ -77,14 +77,26 @@ function SignIn({ isOpen, openerStates, setProfilePic }) {
           localStorage.setItem("AIPLAY_USER_PIC", userData.profile_pic);
           localStorage.setItem("AIPLAY_USER_MEMBERSHIP", userData.membership);
           setUserIdx(userData.idx);
+          setUserNickname(userData.nickname);
           setProfilePic(userData.profile_pic);
           setLoggedIn(true);
           setIsOpen(false);
           setIsSignInOpenFromHome(false);
+
+          // 1시간마다 JWT 갱신 시작
+          setTimeout(() => {
+            refreshTokenInterval.current = setInterval(refreshToken, 1000 * 10 * 60);
+          }, 1000 * 10 * 60);
         } else {
           data.email_state ? alert("비밀번호가 일치하지 않습니다.") : alert("가입하지 않은 이메일입니다.");
         }
       });
+  };
+
+  const handleEnter = (e) => {
+    if (e.key === "Enter") {
+      handleSubmit(e);
+    }
   };
 
   const goToSignUp = (event) => {
@@ -132,7 +144,10 @@ function SignIn({ isOpen, openerStates, setProfilePic }) {
         </div>
 
         <div className="flex flex-row justify-around">
-          <button type="submit" className="border border-blue-500 hover:bg-blue-300 text-black text-sm md:text-xs font-bold w-2/5 py-2 px-2 rounded">
+          <button
+            type="submit"
+            onKeyPress={handleEnter}
+            className="border border-blue-500 hover:bg-blue-300 text-black text-sm md:text-xs font-bold w-2/5 py-2 px-2 rounded">
             로그인
           </button>
         </div>

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,35 @@
+import { targetURL, httpConfig, USER_AUTH_URL, URLS_USER_AUTH } from "MLML/MLComponents/CompoOptions/networkConfigs";
+
+export const refreshToken = async () => {
+  console.log("refresh token");
+  const targetUrl = targetURL(USER_AUTH_URL.concat(URLS_USER_AUTH.refresh_jwt));
+  await fetch(targetUrl, httpConfig(null, "GET"))
+    .then((res) => res.json())
+    .then((res) => {
+      if (res.result) {
+        console.log("refreshToken success", res.result);
+      } else {
+        console.log("refreshToken error: ", res.message);
+      }
+    })
+    .catch((err) => {
+      console.log("refreshToken error: ", err);
+    });
+};
+
+export const removeToken = async () => {
+  console.log("remove token");
+  const targetUrl = targetURL(USER_AUTH_URL.concat(URLS_USER_AUTH.remove_jwt));
+  await fetch(targetUrl, httpConfig(null, "GET"))
+    .then((res) => res.json())
+    .then((res) => {
+      if (res.result) {
+        console.log("removeToken success", res.result);
+      } else {
+        console.log("removeToken error: ", res.message);
+      }
+    })
+    .catch((err) => {
+      console.log("removeToken error: ", err);
+    });
+};


### PR DESCRIPTION
### 작성자
안경호

### 1. 기능 설명
사용자 인증을 위한 JWT 기능 추가

프론트앤드 내부에서의 인증이 아닌 백앤드 서버에서의 사용자 인증을 위해 JWT를 발급받음.

- 발급 서버 : User-Auth
  - 발급 : login + create_jwt
  - 갱신 : refresh_jwt
  - 소멸 : remove_jwt
- 인증 필요 서버 및 기능
  - User-Auth : verify_token(인증용 데코레이터) / nickname_change, pw_change, profile_pic_change, inactive
  - User-Proj-Managing : authenticate(일반 사용자 인증용 데코레이터), adminAuthenticate(관리자 인증용 데코레이터) / routes 전체
  - DL-API : verify_token(인증용 데코레이터) / create_post, update_post, delete_post, read_posts
  - ML-Funcs & ML-Train : 기존 데코레이터 check_error 내에 인증 절차 추가

p.s. 이후 채팅 서버도 JWT 인증되면 입장 가능하도록 변경 필요