### PR TITLE
[FeatureMade] Chatting healthCheck func added

### DIFF
--- a/src/Components/MLML/Chatting/chatApi.js
+++ b/src/Components/MLML/Chatting/chatApi.js
@@ -1,4 +1,12 @@
 let socket;
+let hCheck;
+
+const healthCheck = (repeat = false) => {
+  setTimeout(() => {
+    socket.send(JSON.stringify({ type: 44 }));
+    repeat && healthCheck();
+  }, 1000 * 50);
+};
 
 const connect = (userIdx, userNickname, bodyRef, setMsgs) => {
   socket = new WebSocket(process.env.REACT_APP_CHATTING_URL);
@@ -13,6 +21,7 @@ const connect = (userIdx, userNickname, bodyRef, setMsgs) => {
       nickname: userNickname,
     };
     socket.send(JSON.stringify(message));
+    hCheck = healthCheck(true);
   };
 
   socket.onmessage = (msg) => {
@@ -47,6 +56,7 @@ const disconnect = (userIdx, userNickname) => {
   socket.close();
   sessionStorage.removeItem("chatStart");
   sessionStorage.removeItem("msgs");
+  clearTimeout(hCheck);
 };
 
 const sendMsg = (userIdx, userNickname, msg) => {


### PR DESCRIPTION
### 작성자
안경호

### 1. 기능 설명
사용자 채팅 접속 시 50초마다 연결 유지를 위한 메시지를 서버에 전송하는 기능 추가

Chatting 서버를 배포한 Heroku는 소켓 연결 후 55초간 입력이 없으면 자동으로 Idle 상태가 됨.
즉, 사용자가 가만히 있으면 멋대로 소켓 연결이 끊어져 버림.
이를 방지하기 위하여 사용자가 채팅방에 입장하면 50초마다 Idle 상태에서 벗어나게 만들기 위해 신호(메시지)를 보내줌.

결국 채팅방에 혼자 있기가 가능...